### PR TITLE
Add success check to CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the CD workflow to only run when the CI workflow completes successfully.

## Changes
- Added `if: ${{ github.event.workflow_run.conclusion == 'success' }}` condition to the deploy job
- Ensures deployment only happens after successful CI runs
- Prevents deploying broken builds when CI fails or is cancelled

## Impact
- CD workflow will skip deployment if CI fails
- Manual workflow_dispatch triggers remain available